### PR TITLE
Async support, store span in request attributes, pass request to onError

### DIFF
--- a/opentracing-web-servlet-filter/pom.xml
+++ b/opentracing-web-servlet-filter/pom.xml
@@ -38,6 +38,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.jayway.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${version.com.jayway.awaitility-awaitility}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <version>${version.org.eclipse.jetty}</version>

--- a/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/SpanWrapper.java
+++ b/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/SpanWrapper.java
@@ -1,0 +1,49 @@
+package io.opentracing.contrib.web.servlet.filter;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.servlet.ServletContext;
+
+import io.opentracing.Span;
+
+/**
+ * This is passed to {@link ServletContext#setAttribute(String, Object)} holding server span.
+ *
+ * <p>This wrapper is necessary for higher levels (e.g. spring interceptor, jax-rs) to find out
+ * if the span was finished or not.
+ *
+ * @author Pavol Loffay
+ */
+public class SpanWrapper {
+
+    private Span span;
+    private AtomicBoolean finished = new AtomicBoolean();
+
+    protected SpanWrapper(Span span) {
+        this.span = span;
+    }
+
+    /**
+     * @return server span
+     */
+    public Span get() {
+        return span;
+    }
+
+    /**
+     * @return true if span has been finished
+     */
+    public boolean isFinished() {
+        return finished.get();
+    }
+
+    /**
+     * Idempotent finish
+     */
+    protected void finish() {
+        boolean wasFinished = finished.getAndSet(true);
+        if (!wasFinished) {
+            span.finish();
+        }
+    }
+}

--- a/opentracing-web-servlet-filter/src/test/java/io/opentracing/contrib/web/servlet/filter/TracingFilterTest.java
+++ b/opentracing-web-servlet-filter/src/test/java/io/opentracing/contrib/web/servlet/filter/TracingFilterTest.java
@@ -107,11 +107,11 @@ public class TracingFilterTest extends AbstractJettyTest {
 
         MockSpan mockSpan = mockSpans.get(0);
         Assert.assertEquals("GET", mockSpan.operationName());
-        Assert.assertEquals(5, mockSpan.tags().size());
+        Assert.assertEquals(6, mockSpan.tags().size());
         Assert.assertEquals(Tags.SPAN_KIND_SERVER, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
         Assert.assertEquals("GET", mockSpan.tags().get(Tags.HTTP_METHOD.getKey()));
         Assert.assertEquals(localRequestUrl("/filterException"), mockSpan.tags().get(Tags.HTTP_URL.getKey()));
-//        Assert.assertEquals(500, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
+        Assert.assertEquals(500, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
         Assert.assertEquals("java-web-servlet", mockSpan.tags().get(Tags.COMPONENT.getKey()));
 
         Assert.assertEquals(1, mockSpan.logEntries().size());
@@ -139,11 +139,11 @@ public class TracingFilterTest extends AbstractJettyTest {
 
         MockSpan mockSpan = mockSpans.get(0);
         Assert.assertEquals("GET", mockSpan.operationName());
-        Assert.assertEquals(5, mockSpan.tags().size());
+        Assert.assertEquals(6, mockSpan.tags().size());
         Assert.assertEquals(Tags.SPAN_KIND_SERVER, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
         Assert.assertEquals("GET", mockSpan.tags().get(Tags.HTTP_METHOD.getKey()));
         Assert.assertEquals(localRequestUrl("/servletException"), mockSpan.tags().get(Tags.HTTP_URL.getKey()));
-//        Assert.assertEquals(500, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
+        Assert.assertEquals(500, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
         Assert.assertEquals("java-web-servlet", mockSpan.tags().get(Tags.COMPONENT.getKey()));
 
         Assert.assertEquals(1, mockSpan.logEntries().size());

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <maven.compiler.target>1.7</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+    <version.com.jayway.awaitility-awaitility>1.7.0</version.com.jayway.awaitility-awaitility>
     <version.io.opentracing>0.20.9</version.io.opentracing>
     <version.javax.servlet-javax.servlet-api>3.0.1</version.javax.servlet-javax.servlet-api>
     <version.junit>4.12</version.junit>


### PR DESCRIPTION
* async support: span is finished when a response is returned.
* pass request to `onError`
* decorator `STANDARD_TAGS` can guess 5xx error code.
* store span in request attributes so it can be consumed by higher layers (e.g. spring interceptor).


This depends on https://github.com/opentracing/opentracing-java/pull/98 and new patch version of ot-java.


Things to discuss: 
* currently there is no way to add a log when async started or even it is an async.