### PR TITLE
Use global tracer with default constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,10 @@ Tracing filter can be programmatically initialized:
    servletContext.addFilter("tracingFilter", filter);
 ```
 
-or added to `web.xml`, however it requires to add following properties to ServletContext attributes:
-```java
-   servletContext.setAttribute(TracingFilter.TRACER, tracer);
-   servletContext.setAttribute(TracingFilter.SPAN_DECORATORS, decorators); // optional, if no present ServletFilterSpanDecorator.STANDARD_TAGS is applied
-```
-
-* `SpanDecorator` - decorate span (add tags, logs, change span operation name).
+or added to `web.xml`, however it requires to register a tracer instance: `GlobalTracer.register(tracer)`.
 
 ## Accessing Server Span
-Current server span is accessible in HttpServletRequest attributes.
+Current server span context is accessible in HttpServletRequest attributes.
 ```java
    SpanContext spanContext = (SpanContext)httpservletRequest.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT);
    

--- a/opentracing-web-servlet-filter/pom.xml
+++ b/opentracing-web-servlet-filter/pom.xml
@@ -20,6 +20,10 @@
       <artifactId>opentracing-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-spanmanager</artifactId>
     </dependency>

--- a/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java
+++ b/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java
@@ -2,7 +2,7 @@ package io.opentracing.contrib.web.servlet.filter;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
@@ -24,13 +24,14 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
 
 /**
  * Tracing servlet filter.
  *
  * Filter can be programmatically added to {@link ServletContext} or initialized via web.xml.
  *
- * Following code examples show possible initialization.
+ * Following code examples show possible initialization:
  *
  * <pre>
  * {@code
@@ -42,25 +43,19 @@ import io.opentracing.tag.Tags;
  * Or include filter in web.xml and:
  * <pre>
  * {@code
- *  servletContext.setAttribute({@link TracingFilter#TRACER}, tracer);
- *  servletContext.setAttribute({@link TracingFilter#SPAN_DECORATORS}, decorators); // optional, if no present
- *  ServletFilterSpanDecorator.STANDARD_TAGS is applied
+ *  GlobalTracer.register(tracer);
+ *  servletContext.setAttribute({@link TracingFilter#SPAN_DECORATORS}, decorators); // optional, if no present ServletFilterSpanDecorator.STANDARD_TAGS is applied
  * }
  * </pre>
  *
- * Current server span is accessible via {@link HttpServletRequest#getAttribute(String)} with name
+ * Current server span context is accessible via {@link HttpServletRequest#getAttribute(String)} with name
  * {@link TracingFilter#SERVER_SPAN_CONTEXT}.
  *
  * @author Pavol Loffay
  */
 public class TracingFilter implements Filter {
-
     private static final Logger log = Logger.getLogger(TracingFilter.class.getName());
 
-    /**
-     * Use as a key of {@link ServletContext#setAttribute(String, Object)} to set Tracer
-     */
-    public static final String TRACER = TracingFilter.class.getName() + ".tracer";
     /**
      * Use as a key of {@link ServletContext#setAttribute(String, Object)} to set span decorators
      */
@@ -85,10 +80,11 @@ public class TracingFilter implements Filter {
     private List<ServletFilterSpanDecorator> spanDecorators;
 
     /**
-     * When using this constructor one has to provide required ({@link TracingFilter#TRACER}
-     * attribute in {@link ServletContext#setAttribute(String, Object)}.
+     * Tracer instance has to be registered with {@link GlobalTracer#register(Tracer)}.
      */
-    public TracingFilter() {}
+    public TracingFilter() {
+        this(GlobalTracer.get());
+    }
 
     /**
      * @param tracer
@@ -111,30 +107,18 @@ public class TracingFilter implements Filter {
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         this.filterConfig = filterConfig;
+        ServletContext servletContext = filterConfig.getServletContext();
 
-        // init if the tracer is null
-        if (tracer == null) {
-            ServletContext servletContext = filterConfig.getServletContext();
-
-            Object contextAttribute = servletContext.getAttribute(TRACER);
-            if (contextAttribute == null) {
-                log.severe("Tracer was not found in `ServletContext.getAttribute(TRACER)`, skipping tracing filter");
-                this.skipFilter = true;
-                return;
+        // use decorators from context attributes
+        Object decoratorsAttribute = servletContext.getAttribute(SPAN_DECORATORS);
+        if (decoratorsAttribute != null && !(decoratorsAttribute instanceof Collection)) {
+            List<ServletFilterSpanDecorator> decorators = new ArrayList<>();
+            for (Object decorator: (Collection)decoratorsAttribute) {
+                if (decorator instanceof ServletFilterSpanDecorator) {
+                    decorators.add((ServletFilterSpanDecorator) decorator);
+                }
             }
-            if (!(contextAttribute instanceof Tracer)) {
-                log.severe("Tracer from `ServletContext.getAttribute(TRACER)`, is not an instance of " +
-                        "io.opentracing.Tracer, skipping tracing filter");
-                this.skipFilter = true;
-                return;
-            }
-            this.tracer = (Tracer)contextAttribute;
-
-            this.spanDecorators = (List<ServletFilterSpanDecorator>)servletContext.getAttribute(SPAN_DECORATORS);
-            if (this.spanDecorators == null) {
-                this.spanDecorators = Arrays.asList(ServletFilterSpanDecorator.STANDARD_TAGS);
-            }
-            this.spanDecorators.removeAll(Collections.singleton(null));
+            this.spanDecorators = decorators.size() > 0 ? decorators : this.spanDecorators;
         }
     }
 

--- a/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java
+++ b/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java
@@ -44,7 +44,7 @@ import io.opentracing.util.GlobalTracer;
  * <pre>
  * {@code
  *  GlobalTracer.register(tracer);
- *  servletContext.setAttribute({@link TracingFilter#SPAN_DECORATORS}, decorators); // optional, if no present ServletFilterSpanDecorator.STANDARD_TAGS is applied
+ *  servletContext.setAttribute({@link TracingFilter#SPAN_DECORATORS}, listOfDecorators); // optional, if no present ServletFilterSpanDecorator.STANDARD_TAGS is applied
  * }
  * </pre>
  *
@@ -111,11 +111,13 @@ public class TracingFilter implements Filter {
 
         // use decorators from context attributes
         Object decoratorsAttribute = servletContext.getAttribute(SPAN_DECORATORS);
-        if (decoratorsAttribute != null && !(decoratorsAttribute instanceof Collection)) {
+        if (decoratorsAttribute != null && decoratorsAttribute instanceof Collection) {
             List<ServletFilterSpanDecorator> decorators = new ArrayList<>();
             for (Object decorator: (Collection)decoratorsAttribute) {
                 if (decorator instanceof ServletFilterSpanDecorator) {
                     decorators.add((ServletFilterSpanDecorator) decorator);
+                } else {
+                    log.severe(decorator + " is not an instance of " + ServletFilterSpanDecorator.class);
                 }
             }
             this.spanDecorators = decorators.size() > 0 ? decorators : this.spanDecorators;

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.com.jayway.awaitility-awaitility>1.7.0</version.com.jayway.awaitility-awaitility>
-    <version.io.opentracing>0.20.9</version.io.opentracing>
+    <version.io.opentracing>0.21.0</version.io.opentracing>
     <version.io.opentracing.contrib.spanmanager>0.0.3</version.io.opentracing.contrib.spanmanager>
     <version.javax.servlet-javax.servlet-api>3.0.1</version.javax.servlet-javax.servlet-api>
     <version.junit>4.12</version.junit>
@@ -67,6 +67,11 @@
       <dependency>
         <groupId>io.opentracing</groupId>
         <artifactId>opentracing-api</artifactId>
+        <version>${version.io.opentracing}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-util</artifactId>
         <version>${version.io.opentracing}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
* use `GlobalTracer` when tracer is not explicitly supplied

It should simplify configuration when filter is defined in web.xml