### PR TITLE
Bump spanmanager version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.opentracing>0.21.0</version.io.opentracing>
-    <version.io.opentracing.contrib.spanmanager>0.0.3</version.io.opentracing.contrib.spanmanager>
+    <version.io.opentracing.contrib.spanmanager>0.0.4</version.io.opentracing.contrib.spanmanager>
     <version.javax.servlet-javax.servlet-api>3.0.1</version.javax.servlet-javax.servlet-api>
     <version.junit>4.12</version.junit>
     <version.org.mockito-mockito-all>1.10.19</version.org.mockito-mockito-all>


### PR DESCRIPTION
Version 0.0.4 uses OT-api version 0.21.0.

Probably spanmanager can soon be replaced by included OT api concepts, for now keep API versions in sync