### PR TITLE
Handle headers with no value

### DIFF
--- a/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/HttpServletRequestExtractAdapter.java
+++ b/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/HttpServletRequestExtractAdapter.java
@@ -81,7 +81,11 @@ public class HttpServletRequestExtractAdapter implements TextMap {
                 listIterator = mapEntry.getValue().iterator();
             }
 
-            return new AbstractMap.SimpleImmutableEntry<>(mapEntry.getKey(), listIterator.next());
+            if (listIterator.hasNext()) {
+                return new AbstractMap.SimpleImmutableEntry<>(mapEntry.getKey(), listIterator.next());
+            } else {
+                return new AbstractMap.SimpleImmutableEntry<>(mapEntry.getKey(), null);
+            }
         }
 
         @Override

--- a/opentracing-web-servlet-filter/src/test/java/io/opentracing/contrib/web/servlet/filter/MultivaluedMapFlatIteratorTest.java
+++ b/opentracing-web-servlet-filter/src/test/java/io/opentracing/contrib/web/servlet/filter/MultivaluedMapFlatIteratorTest.java
@@ -28,11 +28,7 @@ public class MultivaluedMapFlatIteratorTest {
         Assert.assertFalse(iterator.hasNext());
     }
 
-    /**
-     * Corner case.
-     * This should not really happen. In this case value should be null or an empty string.
-     */
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testEmptyValue() {
         Map<String, List<String>> map = new HashMap<>();
         map.put("key", Collections.<String>emptyList());
@@ -41,7 +37,8 @@ public class MultivaluedMapFlatIteratorTest {
                 HttpServletRequestExtractAdapter.MultivaluedMapFlatIterator<>(map.entrySet());
 
         Assert.assertTrue(iterator.hasNext());
-        iterator.next();
+        Assert.assertEquals(new AbstractMap.SimpleImmutableEntry<>("key", null), iterator.next());
+        Assert.assertFalse(iterator.hasNext());
     }
 
     @Test


### PR DESCRIPTION
It’s possible to receive a request with header that has no value. In such
case `HttpServletRequest.getHeaders(name)` returns empty `Enumeration`.

This change makes such headers appear as if the header had null value instead of throwing `NoSuchElementException`.

Other options (let me know what you think):
- skip such headers - seems reasonable. This code is used only to extract baggage and span context, so it might makes sense to just skip it. Should be enough to add a check inside `HttpServletRequestExtractAdapter.servletHeadersToMultiMap(req)`
- return empty string instead of null - doesn't fit here well. Additionally `MultivaluedMapFlatIterator` is generic, so it can't be added there.

This solves https://github.com/opentracing-contrib/java-web-servlet-filter/issues/21