### PR TITLE
Allow for overriding tracer field. 

### DIFF
--- a/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java
+++ b/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java
@@ -74,7 +74,7 @@ public class TracingFilter implements Filter {
 
     private FilterConfig filterConfig;
 
-    private Tracer tracer;
+    protected Tracer tracer;
     private List<ServletFilterSpanDecorator> spanDecorators;
     private Pattern skipPattern;
 


### PR DESCRIPTION
This PR allows for subclassing `TracingFilter` and overriding `init` method in order to inject `tracer` created as a Spring bean. 
```java
  @Override
  public void init(FilterConfig config) throws ServletException {
    WebApplicationContext ctx = WebApplicationContextUtils.getRequiredWebApplicationContext(
        config.getServletContext());
    this.tracer = ctx.getBean(Tracer.class);
  }
```

In my case, spring context is created after the filter chain is build. `GlobalTracer` can't be used because there are multiple spring contexts in my app and therefore multiple instances of tracers. 