### PR TITLE
Swallows unchecked IllegalArgumentException on extract

### DIFF
--- a/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java
+++ b/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java
@@ -147,8 +147,13 @@ public class TracingFilter implements Filter {
         if (servletRequest.getAttribute(SERVER_SPAN_CONTEXT) != null) {
             chain.doFilter(servletRequest, servletResponse);
         } else {
-            SpanContext extractedContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
-                    new HttpServletRequestExtractAdapter(httpRequest));
+            SpanContext extractedContext;
+            try {
+                extractedContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
+                        new HttpServletRequestExtractAdapter(httpRequest));
+            } catch (IllegalArgumentException e) {
+                extractedContext = null;
+            }
 
             final Scope scope = tracer.buildSpan(httpRequest.getMethod())
                     .asChildOf(extractedContext)


### PR DESCRIPTION
OpenTracing implementations may throw an `IllegalArgumentException` (see [here](https://github.com/opentracing/opentracing-java/blob/d988630cb2dcb3544f116327464039bf07848293/opentracing-api/src/main/java/io/opentracing/Tracer.java#L93)) when there are issues deserializing the span state (e.g. a client sending corrupted header).

This exception should be swallowed so that the request can still be processed.