### PR TITLE
Adding MDCSpanDecorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ target
 .classpath
 .settings
 
+# IntelliJ
+*.iml
+.idea/

--- a/opentracing-web-servlet-filter-mdc/pom.xml
+++ b/opentracing-web-servlet-filter-mdc/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2018 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-web-servlet-filter-parent</artifactId>
+    <version>0.2.3-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>opentracing-web-servlet-filter-mdc</artifactId>
+
+  <properties>
+    <version.org.eclipse.jetty>9.3.15.v20161220</version.org.eclipse.jetty>
+    <version.com.squareup.okhttp3>3.5.0</version.com.squareup.okhttp3>
+    <version.org.mockito>1.10.19</version.org.mockito>
+    <version.ch.qos.logback>1.1.11</version.ch.qos.logback>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <version.org.slf4j>1.7.25</version.org.slf4j>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${version.org.slf4j}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>opentracing-web-servlet-filter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>${version.javax.servlet-javax.servlet-api}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${version.ch.qos.logback}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>${version.ch.qos.logback}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/opentracing-web-servlet-filter-mdc/src/main/java/io/opentracing/contrib/mdc/MDCSpanDecorator.java
+++ b/opentracing-web-servlet-filter-mdc/src/main/java/io/opentracing/contrib/mdc/MDCSpanDecorator.java
@@ -1,0 +1,76 @@
+package io.opentracing.contrib.mdc;
+
+import io.opentracing.Span;
+import io.opentracing.tag.StringTag;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.MDC;
+
+public class MDCSpanDecorator {
+
+    private final String baseTagKey;
+    private final List<MDCEntry> mdcEntries;
+
+    public MDCSpanDecorator(List<MDCEntry> mdcEntry) {
+        this(mdcEntry, "mdc");
+    }
+
+    public MDCSpanDecorator(List<MDCEntry> mdcEntry, String baseTagKey) {
+        this.mdcEntries = new ArrayList<>(mdcEntry);
+        this.baseTagKey = (baseTagKey != null && !baseTagKey.isEmpty()) ? baseTagKey + "." : null;
+    }
+
+    public void decorate(Span span) {
+        for (MDCEntry mdcEntry : mdcEntries) {
+            String mdcValue = MDC.get(mdcEntry.getKey());
+            if (mdcValue != null && !mdcValue.isEmpty()) {
+                buildTag(mdcEntry.getTag()).set(span, mdcValue);
+            }
+        }
+    }
+
+    private StringTag buildTag(String tag) {
+        if (baseTagKey == null) {
+            return new StringTag(tag);
+        }
+        return new StringTag(baseTagKey + tag);
+    }
+
+    protected String getBaseTagKey() {
+        return this.baseTagKey;
+    }
+
+    protected List<MDCEntry> getMdcEntries() {
+        return this.mdcEntries;
+    }
+
+    public static class MDCEntry {
+        private String key;
+        private String tag;
+
+        public MDCEntry(String key, String tag) {
+            this.key = key;
+            this.tag = tag;
+        }
+
+        public MDCEntry() {
+        }
+
+        public String getKey() {
+            return this.key;
+        }
+
+        public String getTag() {
+            return this.tag;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        public void setTag(String tag) {
+            this.tag = tag;
+        }
+    }
+
+}

--- a/opentracing-web-servlet-filter-mdc/src/main/java/io/opentracing/contrib/web/servlet/filter/ServletFilterMDCSpanDecorator.java
+++ b/opentracing-web-servlet-filter-mdc/src/main/java/io/opentracing/contrib/web/servlet/filter/ServletFilterMDCSpanDecorator.java
@@ -1,0 +1,43 @@
+package io.opentracing.contrib.web.servlet.filter;
+
+import io.opentracing.Span;
+import io.opentracing.contrib.mdc.MDCSpanDecorator;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ServletFilterMDCSpanDecorator implements ServletFilterSpanDecorator {
+
+    private final MDCSpanDecorator spanDecorator;
+
+    public ServletFilterMDCSpanDecorator(MDCSpanDecorator spanDecorator) {
+        this.spanDecorator = spanDecorator;
+    }
+
+    @Override
+    public void onRequest(HttpServletRequest httpServletRequest, Span span) {
+        spanDecorator.decorate(span);
+    }
+
+    @Override
+    public void onResponse(HttpServletRequest httpServletRequest,
+        HttpServletResponse httpServletResponse, Span span) {
+
+    }
+
+    @Override
+    public void onError(HttpServletRequest httpServletRequest,
+        HttpServletResponse httpServletResponse, Throwable exception, Span span) {
+
+    }
+
+    @Override
+    public void onTimeout(HttpServletRequest httpServletRequest,
+        HttpServletResponse httpServletResponse, long timeout, Span span) {
+
+    }
+
+    public MDCSpanDecorator getSpanDecorator() {
+        return spanDecorator;
+    }
+
+}

--- a/opentracing-web-servlet-filter-mdc/test/java/io/opentracing/contrib/mdc/MDCSpanDecoratorTest.java
+++ b/opentracing-web-servlet-filter-mdc/test/java/io/opentracing/contrib/mdc/MDCSpanDecoratorTest.java
@@ -1,0 +1,77 @@
+package io.opentracing.contrib.mdc;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import io.opentracing.Span;
+import io.opentracing.contrib.mdc.MDCSpanDecorator.MDCEntry;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.MDC;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MDCSpanDecoratorTest {
+
+    @Mock
+    private Span span;
+
+    private List<MDCEntry> mdcEntries = new ArrayList<>();
+    private MDCSpanDecorator decorator;
+
+    @Before
+    public void init() {
+        MDC.clear();
+        mdcEntries.add(new MDCEntry("key1", "tag"));
+        decorator = new MDCSpanDecorator(mdcEntries);
+    }
+
+    @After
+    public void after() {
+        MDC.clear();
+    }
+
+    @Test
+    public void givenMdcEntry_whenDecorathingSpan_thenItShouldAddTag() {
+        MDC.put("key1", "val1");
+        decorator.decorate(span);
+        verify(span).setTag("mdc.tag", "val1");
+    }
+
+    @Test
+    public void givenMdcEntry_whenDecorathingSpan_thenItShouldIgnoreUnpappedTag() {
+        MDC.put("key1", "val1");
+        MDC.put("key2", "val2");
+        decorator.decorate(span);
+        verify(span).setTag(anyString(), anyString());
+    }
+    
+    @Test
+    public void givenUnmappedMdcEntry_whenDecorathingSpan_thenItShouldIgnoreUnmappedTag() {
+        MDC.put("key2", "val2");
+        decorator.decorate(span);
+        verifyZeroInteractions(span);
+    }
+    
+    @Test
+    public void givenEmptyMdcEntry_whenDecorathingSpan_thenItShouldIgnoreUnMappedTag() {
+        decorator = new MDCSpanDecorator(new ArrayList<MDCEntry>());
+        decorator.decorate(span);
+        verifyZeroInteractions(span);
+    }
+    
+    @Test
+    public void givenCustomTag_whenDecorathingSpan_thenItShouldTag() {
+        MDC.put("key1", "val1");
+        decorator = new MDCSpanDecorator(mdcEntries, "");
+        decorator.decorate(span);
+        verify(span).setTag("tag", "val1");
+    }
+
+}

--- a/opentracing-web-servlet-filter-mdc/test/java/io/opentracing/contrib/web/servlet/filter/ServletFilterMDCSpanDecoratorTest.java
+++ b/opentracing-web-servlet-filter-mdc/test/java/io/opentracing/contrib/web/servlet/filter/ServletFilterMDCSpanDecoratorTest.java
@@ -1,0 +1,77 @@
+package io.opentracing.contrib.web.servlet.filter.decorator;
+
+import io.opentracing.Span;
+import io.opentracing.contrib.mdc.MDCSpanDecorator;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServletFilterMDCSpanDecoratorTest {
+
+    @Mock
+    private MDCSpanDecorator mdcDecorator;
+    @Mock
+    private HttpServletRequest httpServletRequest;
+    @Mock
+    private HttpServletResponse httpServletResponse;
+    @Mock
+    private Exception exception;
+    @Mock
+    private Span span;
+
+    private ServletFilterMDCSpanDecorator decorator;
+
+    @Before
+    public void init() {
+        decorator = new ServletFilterMDCSpanDecorator(mdcDecorator);
+    }
+
+    @Test
+    public void givenMdcDecorator_whenOnRequestIsCalled_thenDecoratorIsCalled() {
+        decorator.onRequest(httpServletRequest, span);
+
+        Mockito.verify(mdcDecorator).decorate(Matchers.same(span));
+    }
+
+    @Test
+    public void givenMdcDecorator_whenOnRequestIsCalled__thenParamAreNeverUsed() {
+        decorator.onRequest(httpServletRequest, span);
+
+        Mockito.verifyZeroInteractions(span);
+        Mockito.verifyZeroInteractions(httpServletRequest);
+    }
+
+    @Test
+    public void givenMdcDecorator_whenOnResponseIsCalled_thenParamAreNeverUsed() {
+        decorator.onResponse(httpServletRequest, httpServletResponse, span);
+
+        Mockito.verifyZeroInteractions(span);
+        Mockito.verifyZeroInteractions(httpServletResponse);
+        Mockito.verifyZeroInteractions(httpServletRequest);
+    }
+
+    @Test
+    public void givenMdcDecorator_whenOnErrorIsCalled_thenParamAreNeverUsed() {
+        decorator.onError(httpServletRequest, httpServletResponse, exception, span);
+
+        Mockito.verifyZeroInteractions(span);
+        Mockito.verifyZeroInteractions(httpServletResponse);
+        Mockito.verifyZeroInteractions(exception);
+        Mockito.verifyZeroInteractions(httpServletRequest);
+    }
+
+    @Test
+    public void givenMdcDecorator_whenOnTimeoutdIsCalled_thenMdcDecoratorIsNeverUsed() {
+        decorator.onTimeout(httpServletRequest, httpServletResponse, 1, span);
+
+        Mockito.verifyZeroInteractions(mdcDecorator);
+    }
+
+}

--- a/opentracing-web-servlet-filter-mdc/test/resources/jetty-logging.properties
+++ b/opentracing-web-servlet-filter-mdc/test/resources/jetty-logging.properties
@@ -1,0 +1,6 @@
+# Configure Jetty for StdErrLog Logging
+org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StrErrLog
+# Overall Logging Level is INFO
+org.eclipse.jetty.LEVEL=INFO
+# Detail Logging for WebSocket
+org.eclipse.jetty.websocket.LEVEL=DEBUG

--- a/opentracing-web-servlet-filter/pom.xml
+++ b/opentracing-web-servlet-filter/pom.xml
@@ -27,6 +27,7 @@
   <properties>
     <version.org.eclipse.jetty>9.3.15.v20161220</version.org.eclipse.jetty>
     <version.com.squareup.okhttp3>3.5.0</version.com.squareup.okhttp3>
+    <version.org.mockito>1.10.19</version.org.mockito>
     <main.basedir>${project.basedir}/..</main.basedir>
   </properties>
 
@@ -56,6 +57,12 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>${version.org.awaitility-awaitility}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${version.org.mockito}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/decorator/ServletFilterHeaderSpanDecorator.java
+++ b/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/decorator/ServletFilterHeaderSpanDecorator.java
@@ -1,0 +1,95 @@
+package io.opentracing.contrib.web.servlet.filter.decorator;
+
+import io.opentracing.Span;
+import io.opentracing.contrib.web.servlet.filter.ServletFilterSpanDecorator;
+import io.opentracing.tag.StringTag;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ServletFilterHeaderSpanDecorator implements ServletFilterSpanDecorator {
+
+    private final String baseTagKey;
+    private final List<HeaderEntry> headers;
+
+    public ServletFilterHeaderSpanDecorator(List<HeaderEntry> headers) {
+        this(headers, "http.header");
+    }
+
+    public ServletFilterHeaderSpanDecorator(List<HeaderEntry> headers, String baseTagKey) {
+        this.headers = new ArrayList<>(headers);
+        this.baseTagKey = (baseTagKey != null && !baseTagKey.isEmpty()) ? (baseTagKey + ".") : null;
+    }
+
+    @Override
+    public void onRequest(HttpServletRequest httpServletRequest, Span span) {
+        for (HeaderEntry headerEntry : headers) {
+            String headerValue = httpServletRequest.getHeader(headerEntry.getHeader());
+            if (headerValue != null && !headerValue.isEmpty()) {
+                buildTag(headerEntry.getTag()).set(span, headerValue);
+            }
+        }
+    }
+
+    @Override
+    public void onResponse(HttpServletRequest httpServletRequest,
+        HttpServletResponse httpServletResponse, Span span) {
+    }
+
+    @Override
+    public void onError(HttpServletRequest httpServletRequest,
+        HttpServletResponse httpServletResponse, Throwable exception, Span span) {
+    }
+
+    @Override
+    public void onTimeout(HttpServletRequest httpServletRequest,
+        HttpServletResponse httpServletResponse, long timeout, Span span) {
+    }
+
+    private StringTag buildTag(String tag) {
+        if (baseTagKey == null) {
+            return new StringTag(tag);
+        }
+        return new StringTag(baseTagKey + tag);
+    }
+
+    public String getBaseTagKey() {
+        return this.baseTagKey;
+    }
+
+    public List<HeaderEntry> getHeaders() {
+        return this.headers;
+    }
+
+    public static class HeaderEntry {
+        private String header;
+        private String tag;
+
+        public HeaderEntry(String header, String tag) {
+            this.header = header;
+            this.tag = tag;
+        }
+
+        public HeaderEntry() {
+        }
+
+        public String getHeader() {
+            return this.header;
+        }
+
+        public String getTag() {
+            return this.tag;
+        }
+
+        public void setHeader(String header) {
+            this.header = header;
+        }
+
+        public void setTag(String tag) {
+            this.tag = tag;
+        }
+
+    }
+
+}

--- a/opentracing-web-servlet-filter/src/test/java/io/opentracing/contrib/web/servlet/filter/decorator/ServletFilterHeaderSpanDecoratorTest.java
+++ b/opentracing-web-servlet-filter/src/test/java/io/opentracing/contrib/web/servlet/filter/decorator/ServletFilterHeaderSpanDecoratorTest.java
@@ -1,0 +1,74 @@
+package io.opentracing.contrib.web.servlet.filter.decorator;
+
+
+import io.opentracing.Span;
+import io.opentracing.contrib.web.servlet.filter.decorator.ServletFilterHeaderSpanDecorator.HeaderEntry;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServletFilterHeaderSpanDecoratorTest {
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+    @Mock
+    private Span span;
+
+    private List<HeaderEntry> headerEntries = new ArrayList<>();
+
+    private ServletFilterHeaderSpanDecorator decorator;
+
+    @Before
+    public void init() {
+        headerEntries.add(new HeaderEntry("If-Match", "if-match"));
+        decorator = new ServletFilterHeaderSpanDecorator(headerEntries);
+    }
+
+    @Test
+    public void givenMatchingHeaderEntry_whenOnRequest_thenItShouldAddTag() {
+        Mockito.when(httpServletRequest.getHeader("If-Match")).thenReturn("10");
+
+        decorator.onRequest(httpServletRequest, span);
+        Mockito.verify(span).setTag("http.header.if-match", "10");
+    }
+
+    @Test
+    public void givenNonMatchingHeaderEntry_whenOnRequest_thenItShouldNotAddTag() {
+        decorator.onRequest(httpServletRequest, span);
+        Mockito.verifyZeroInteractions(span);
+    }
+
+    @Test
+    public void givenEmptyMatchingHeaderEntry_whenOnRequest_thenItShouldNotAddTag() {
+        Mockito.when(httpServletRequest.getHeader("If-Match")).thenReturn("");
+
+        decorator.onRequest(httpServletRequest, span);
+        Mockito.verifyZeroInteractions(span);
+    }
+
+    @Test
+    public void givenCustomTag_whenOnRequest_thenItShouldNotAddTag() {
+        decorator = new ServletFilterHeaderSpanDecorator(headerEntries, "HEADER");
+        Mockito.when(httpServletRequest.getHeader("If-Match")).thenReturn("10");
+
+        decorator.onRequest(httpServletRequest, span);
+        Mockito.verify(span).setTag("HEADER.if-match", "10");
+    }
+    
+    @Test
+    public void givenEmptyCustomTag_whenOnRequest_thenItShouldNotAddTag() {
+        decorator = new ServletFilterHeaderSpanDecorator(headerEntries, "");
+        Mockito.when(httpServletRequest.getHeader("If-Match")).thenReturn("10");
+
+        decorator.onRequest(httpServletRequest, span);
+        Mockito.verify(span).setTag("if-match", "10");
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
 
   <modules>
     <module>opentracing-web-servlet-filter</module>
+    <module>opentracing-web-servlet-filter-mdc</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
This PR implements an MDCSpanDecorator and a HeaderSpanDecorator to decorate incoming span on the servlet-filter.

This has been in use internally for some time and we've found that both Header and MDC are useful when adding tracing to existing service.

There will be other related PR to `java-spring-web` and `java-spring-cloud`

cc @jfbreault