### PR TITLE
Use more recent java.servlet API 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <version.io.opentracing>0.32.0</version.io.opentracing>
-    <version.javax.servlet-javax.servlet-api>3.0.1</version.javax.servlet-javax.servlet-api>
+    <version.javax.servlet-javax.servlet-api>3.1.0</version.javax.servlet-javax.servlet-api>
     <version.junit>4.12</version.junit>
     <version.org.mockito-mockito-all>1.10.19</version.org.mockito-mockito-all>
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>


### PR DESCRIPTION
Perhaps we could bump the servlet specification to a more recent version? `3.0.1` is quite old, `3.1.0` is more recent but perhaps the project could move all the way forward to `4.0.1`? 