### PR TITLE
Bump OpenTracing API to 0.32.0

### DIFF
--- a/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java
+++ b/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java
@@ -14,6 +14,7 @@
  */
 package io.opentracing.contrib.web.servlet.filter;
 
+import io.opentracing.Span;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -173,28 +174,30 @@ public class TracingFilter implements Filter {
             SpanContext extractedContext = tracer.extract(Format.Builtin.HTTP_HEADERS,
                     new HttpServletRequestExtractAdapter(httpRequest));
 
-            final Scope scope = tracer.buildSpan(httpRequest.getMethod())
+            final Span span = tracer.buildSpan(httpRequest.getMethod())
                     .asChildOf(extractedContext)
                     .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
-                    .startActive(false);
+                    .start();
 
-            httpRequest.setAttribute(SERVER_SPAN_CONTEXT, scope.span().context());
+            httpRequest.setAttribute(SERVER_SPAN_CONTEXT, span.context());
 
             for (ServletFilterSpanDecorator spanDecorator: spanDecorators) {
-                spanDecorator.onRequest(httpRequest, scope.span());
+                spanDecorator.onRequest(httpRequest, span);
             }
 
             try {
-                chain.doFilter(servletRequest, servletResponse);
+                try (Scope scope = tracer.activateSpan(span)) {
+                    chain.doFilter(servletRequest, servletResponse);
+                }
                 if (!httpRequest.isAsyncStarted()) {
                     for (ServletFilterSpanDecorator spanDecorator : spanDecorators) {
-                        spanDecorator.onResponse(httpRequest, httpResponse, scope.span());
+                        spanDecorator.onResponse(httpRequest, httpResponse, span);
                     }
                 }
                 // catch all exceptions (e.g. RuntimeException, ServletException...)
             } catch (Throwable ex) {
                 for (ServletFilterSpanDecorator spanDecorator : spanDecorators) {
-                    spanDecorator.onError(httpRequest, httpResponse, ex, scope.span());
+                    spanDecorator.onError(httpRequest, httpResponse, ex, span);
                 }
                 throw ex;
             } finally {
@@ -209,9 +212,9 @@ public class TracingFilter implements Filter {
                             for (ServletFilterSpanDecorator spanDecorator: spanDecorators) {
                                     spanDecorator.onResponse(httpRequest,
                                     httpResponse,
-                                    scope.span());
+                                    span);
                             }
-                            scope.span().finish();
+                            span.finish();
                         }
 
                         @Override
@@ -222,7 +225,7 @@ public class TracingFilter implements Filter {
                                   spanDecorator.onTimeout(httpRequest,
                                       httpResponse,
                                       event.getAsyncContext().getTimeout(),
-                                      scope.span());
+                                      span);
                               }
                         }
 
@@ -234,7 +237,7 @@ public class TracingFilter implements Filter {
                                 spanDecorator.onError(httpRequest,
                                     httpResponse,
                                     event.getThrowable(),
-                                    scope.span());
+                                    span);
                             }
                         }
 
@@ -246,9 +249,8 @@ public class TracingFilter implements Filter {
                     // If not async, then need to explicitly finish the span associated with the scope.
                     // This is necessary, as we don't know whether this request is being handled
                     // asynchronously until after the scope has already been started.
-                    scope.span().finish();
+                    span.finish();
                 }
-                scope.close();
             }
         }
     }

--- a/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java
+++ b/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java
@@ -185,16 +185,14 @@ public class TracingFilter implements Filter {
                 spanDecorator.onRequest(httpRequest, span);
             }
 
-            try {
-                try (Scope scope = tracer.activateSpan(span)) {
-                    chain.doFilter(servletRequest, servletResponse);
-                }
+            try (Scope scope = tracer.activateSpan(span)) {
+                chain.doFilter(servletRequest, servletResponse);
                 if (!httpRequest.isAsyncStarted()) {
                     for (ServletFilterSpanDecorator spanDecorator : spanDecorators) {
                         spanDecorator.onResponse(httpRequest, httpResponse, span);
                     }
                 }
-                // catch all exceptions (e.g. RuntimeException, ServletException...)
+            // catch all exceptions (e.g. RuntimeException, ServletException...)
             } catch (Throwable ex) {
                 for (ServletFilterSpanDecorator spanDecorator : spanDecorators) {
                     spanDecorator.onError(httpRequest, httpResponse, ex, span);

--- a/opentracing-web-servlet-filter/src/test/java/io/opentracing/contrib/web/servlet/filter/AbstractJettyTest.java
+++ b/opentracing-web-servlet-filter/src/test/java/io/opentracing/contrib/web/servlet/filter/AbstractJettyTest.java
@@ -156,7 +156,7 @@ public abstract class AbstractJettyTest {
             SpanContext spanContext = (SpanContext)request.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT);
             tracer.buildSpan("localSpan")
                     .asChildOf(spanContext)
-                    .startManual()
+                    .start()
                     .finish();
         }
     }

--- a/opentracing-web-servlet-filter/src/test/java/io/opentracing/contrib/web/servlet/filter/TracingFilterTest.java
+++ b/opentracing-web-servlet-filter/src/test/java/io/opentracing/contrib/web/servlet/filter/TracingFilterTest.java
@@ -182,7 +182,7 @@ public class TracingFilterTest extends AbstractJettyTest {
 
     @Test
     public void testSpanContextPropagation() throws IOException {
-        MockSpan foo = (MockSpan) mockTracer.buildSpan("foo").startManual();
+        MockSpan foo = mockTracer.buildSpan("foo").start();
         {
             Map<String, String> injectMap = new HashMap<>();
             mockTracer.inject(foo.context(), Format.Builtin.HTTP_HEADERS, new TextMapAdapter(injectMap));


### PR DESCRIPTION
It was done in one of the previous PRs, now I am just removing use of deprecated APIs

Signed-off-by: Pavol Loffay <ploffay@redhat.com>